### PR TITLE
Generate UUID for new Projects

### DIFF
--- a/qml/pages/AddProject.qml
+++ b/qml/pages/AddProject.qml
@@ -344,6 +344,9 @@ Dialog {
             }
 
             Component.onCompleted: {
+                if (!projectId) {
+                    projectId = db.getUniqueId().toString()
+                }
                 getTasks()
                 if (editMode) {
                     nameTextArea.text = name

--- a/src/Database.h
+++ b/src/Database.h
@@ -75,13 +75,12 @@ public slots:
 
   void resetDatabase();
 
+  QUuid getUniqueId();
 
 private:
   QSqlDatabase *db;
 
   Q_DISABLE_COPY(Database)
-
-  QUuid getUniqueId();
 
   bool fileExists(QString path);
 


### PR DESCRIPTION
This prevents saving Tasks with nulled projectId and showing all tasks
when adding new Project.

Maybe we should also delete Tasks with nulled projectId on db update.