### PR TITLE
fix typo that lead to ReferenceError

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -81,7 +81,7 @@ CoverBackground {
                 } else {
                     // BreakTimer was not running -> this is now a manual add button
                     var fromCover = true
-                    firsPage.addHoursManually(fromCover)
+                    firstPage.addHoursManually(fromCover)
                     appWindow.activate()
                 }
             }


### PR DESCRIPTION
Currently, clicking on the "Add hours" action of the cover page, is without effect. Turns out, it's caused by a typo: 

> [W] unknown:84 - file:///usr/share/harbour-workinghourstracker/qml/cover/CoverPage.qml:84: ReferenceError: firsPage is not defined

Thus, the fix is straightforward :)